### PR TITLE
Add 'key' prop to elements rendered with v-for.

### DIFF
--- a/template_src/src/assets/vue/pages/dynamic-route.vue
+++ b/template_src/src/assets/vue/pages/dynamic-route.vue
@@ -8,12 +8,12 @@
 				<li><b>Hash:</b> {{$route.hash}}</li>
 				<li><b>Params:</b>
 					<ul>
-						<li v-for="(value, key) in $route.params"><b>{{key}}:</b> {{value}}</li>
+						<li v-for="(value, key) in $route.params" :key="'param-' + key"><b>{{key}}:</b> {{value}}</li>
 					</ul>
 				</li>
 				<li><b>Query:</b>
 					<ul>
-						<li v-for="(value, key) in $route.query"><b>{{key}}:</b> {{value}}</li>
+						<li v-for="(value, key) in $route.query" :key="'param-' + key"><b>{{key}}:</b> {{value}}</li>
 					</ul>
 				</li>
 				<li><b>Route:</b> {{$route.route}}</li>

--- a/template_src/src/assets/vue/pages/dynamic-route.vue
+++ b/template_src/src/assets/vue/pages/dynamic-route.vue
@@ -13,7 +13,7 @@
 				</li>
 				<li><b>Query:</b>
 					<ul>
-						<li v-for="(value, key) in $route.query" :key="'param-' + key"><b>{{key}}:</b> {{value}}</li>
+						<li v-for="(value, key) in $route.query" :key="'query-' + key"><b>{{key}}:</b> {{value}}</li>
 					</ul>
 				</li>
 				<li><b>Route:</b> {{$route.route}}</li>

--- a/template_src/src/assets/vue/pages/form.vue
+++ b/template_src/src/assets/vue/pages/form.vue
@@ -83,12 +83,12 @@
 		
 		<f7-block-title>Checkboxes</f7-block-title>
 		<f7-list form>
-			<f7-list-item v-for="n in 3" checkbox name="my-checkbox" :value="n" :title="'Checkbox ' + n"></f7-list-item>
+			<f7-list-item v-for="n in 3" checkbox name="my-checkbox" :value="n" :title="'Checkbox ' + n" :key="'checkbox-' + n"></f7-list-item>
 		</f7-list>
 		
 		<f7-block-title>Radios</f7-block-title>
 		<f7-list form>
-			<f7-list-item v-for="n in 3" radio name="my-radio" :checked="n === 1" :value="n" :title="'Radio ' + n"></f7-list-item>
+			<f7-list-item v-for="n in 3" radio name="my-radio" :checked="n === 1" :value="n" :title="'Radio ' + n" :key="'radio-' + n"></f7-list-item>
 		</f7-list>
 		
 		<f7-block-title>Buttons</f7-block-title>


### PR DESCRIPTION
As of vue 2.2.0, when using v-for to render a list of elements the `key` prop is required for them
([more about this in Vue.js docs](https://vuejs.org/v2/guide/list.html#key)).