### PR TITLE
more responsive default webpack file watch option

### DIFF
--- a/template_src/webpack.config.js
+++ b/template_src/webpack.config.js
@@ -98,7 +98,8 @@ let config = function (env) {
         stats: {colors: true},
         watchOptions: {
           aggregateTimeout: 300,
-          poll: 1000
+          poll: 100,
+          ignored: /node_modules|platforms/,
         },
         headers: {
           "Access-Control-Allow-Origin": "*"


### PR DESCRIPTION
exclude node_modules and platforms folders, saving cpu usage.
poll time change from 1000 to 100.