### PR TITLE
Security: update `serialize-javascript` to `2.1.2`

### DIFF
--- a/template_src/package.json
+++ b/template_src/package.json
@@ -30,7 +30,7 @@
     "sass-loader": "^8.0.0",
     "style-loader": "^1.0.0",
     "svg-url-loader": "^3.0.2",
-    "terser-webpack-plugin": "^2.1.0",
+    "terser-webpack-plugin": "^2.3.0",
     "url-loader": "^3.0.0",
     "vue-hot-reload-api": "^2.3.4",
     "vue-html-loader": "^1.2.4",


### PR DESCRIPTION
- Security: update `serialize-javascript` to `2.1.2`
- Support Webpack 5

---

[`terser-webpack-plugin` Changelog](https://github.com/webpack-contrib/terser-webpack-plugin/blob/master/CHANGELOG.md#231-2019-12-17)